### PR TITLE
Update test file & fix testing failing on nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
-          - '1'
-          - 'nightly'
+          - "1"
+          - "nightly"
         os:
           - ubuntu-latest
           - macOS-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,13 @@
 name = "DICOM"
 uuid = "a26e6606-dd52-5f6a-a97f-4f611373d757"
-version = "0.10.1"
+version = "0.11.0"
 
 [compat]
-julia = "0.7, 1"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Downloads"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Test
 using DICOM
+using Downloads
 
 const data_folder = joinpath(@__DIR__, "testdata")
 if !isdir(data_folder)
@@ -34,7 +35,7 @@ function download_dicom(filename; folder = data_folder)
     url = dicom_samples[filename]
     filepath = joinpath(folder, filename)
     if !isfile(filepath)
-        download(url, filepath)
+        Downloads.download(url, filepath)
     end
     return filepath
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,8 +25,8 @@ const dicom_samples = Dict(
         "https://github.com/notZaki/DICOMSamples/raw/master/DICOMSamples/OT_Implicit_Little_Headless.dcm",
     "US_Explicit_Big_RGB.dcm" =>
         "https://github.com/notZaki/DICOMSamples/raw/master/DICOMSamples/US_Explicit_Big_RGB.dcm",
-    # "DX_Implicit_Little_Interleaved.dcm" =>
-    #    "https://github.com/OHIF/viewer-testdata/raw/master/dcm/zoo-exotic/5.dcm",
+    "DX_Implicit_Little_Interleaved.dcm" =>
+        "https://github.com/notZaki/DICOMSamples/raw/master/DICOMSamples/DX_Implicit_Little_Interleaved.dcm",
 )
 
 function download_dicom(filename; folder = data_folder)
@@ -185,13 +185,11 @@ end
     @test size(dcmUS[(0x7fe0, 0x0010)]) == (480, 640, 3)
 end
 
-#==
 @testset "Test interleaved" begin
     fileDX = download_dicom("DX_Implicit_Little_Interleaved.dcm")
     dcmDX = dcm_parse(fileDX)
     @test size(dcmDX[(0x7fe0, 0x0010)]) == (1590, 2593, 3)
 end
-==#
 
 @testset "Test Compressed" begin
     fileCT = download_dicom("CT_JPEG70.dcm")


### PR DESCRIPTION
- Changes minimum julia version to 1.6 (LTS), and uses the newer Downloads.download API in tests
- Updates one of the broken URLs for the test files